### PR TITLE
Add optional Firebase Auth emulator configuration to FirebaseAuthMgr

### DIFF
--- a/Assets/Scripts/Network/FirebaseAuthMgr.cs
+++ b/Assets/Scripts/Network/FirebaseAuthMgr.cs
@@ -30,6 +30,11 @@ public class FirebaseAuthMgr : MonoBehaviour
     public Text warningText;
     public Text confirmText;
 
+    [Header("Auth Emulator (optional)")]
+    [SerializeField] private bool useAuthEmulator;
+    [SerializeField] private string authEmulatorHost = "127.0.0.1";
+    [SerializeField] private int authEmulatorPort = 9099;
+
     private bool _isFirebaseReady;
 
 
@@ -51,6 +56,7 @@ public class FirebaseAuthMgr : MonoBehaviour
 
                 // 3) 인증 인스턴스도 여기서 꺼내기
                 auth = FirebaseAuth.DefaultInstance;
+                ConfigureAuthEmulator();
 
                 _databaseRoot = FirebaseDatabase.GetInstance(app).RootReference;
                 _isFirebaseReady = true;
@@ -71,6 +77,25 @@ public class FirebaseAuthMgr : MonoBehaviour
         LoginBtn.onClick.AddListener(() => { Login(); });
         RegisterBtn.onClick.AddListener(() => { Register(); });
         CreateIDBtn.onClick.AddListener(() => { CreateID(); });
+    }
+
+    private void ConfigureAuthEmulator()
+    {
+        if (auth == null)
+        {
+            return;
+        }
+
+        string useEmulatorEnv = Environment.GetEnvironmentVariable("USE_AUTH_EMULATOR");
+        bool hasEnvOptIn = useEmulatorEnv == "1" || string.Equals(useEmulatorEnv, "true", StringComparison.OrdinalIgnoreCase);
+
+        if (!useAuthEmulator && !hasEnvOptIn)
+        {
+            return;
+        }
+
+        auth.UseEmulator(authEmulatorHost, authEmulatorPort);
+        Debug.Log($"[FirebaseAuthMgr] Auth emulator enabled: {authEmulatorHost}:{authEmulatorPort}");
     }
     private void Start()
     {


### PR DESCRIPTION
### Motivation
- Provide a controlled opt-in path for using the Firebase Auth emulator during local development and testing.
- Make emulator activation possible either via an Inspector toggle or an environment variable to avoid changing production behavior by default.

### Description
- Added Inspector-configurable fields `useAuthEmulator`, `authEmulatorHost`, and `authEmulatorPort` to `FirebaseAuthMgr` for optional emulator configuration.
- Invoke `ConfigureAuthEmulator()` immediately after creating `FirebaseAuth.DefaultInstance` so the auth instance can be re-pointed before use.
- Implemented `ConfigureAuthEmulator()` which enables the emulator when `useAuthEmulator` is true or when the `USE_AUTH_EMULATOR` environment variable is set to `1` or `true`, and calls `auth.UseEmulator(host, port)`.
- Added a runtime `Debug.Log` message to indicate when emulator mode is enabled for clearer runtime diagnostics.

### Testing
- Verified the code change via `git diff -- Assets/Scripts/Network/FirebaseAuthMgr.cs` which displayed the expected modifications and succeeded.
- Committed the change with `git add` and `git commit` and confirmed the commit with `git log -1 --oneline`, all of which succeeded.
- No automated Unity runtime or unit tests were available in this environment to run against the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d13f1c6483308d9f746fe1bef6e3)