### PR TITLE
Restore profile bootstrap when Firebase user snapshot is missing

### DIFF
--- a/Assets/Scripts/Network/FirebaseAuthMgr.cs
+++ b/Assets/Scripts/Network/FirebaseAuthMgr.cs
@@ -204,7 +204,22 @@ public class FirebaseAuthMgr : MonoBehaviour
 
         if (!snapshot.Exists)
         {
-            onCompleted?.Invoke(false, "DB에 등록된 유저 데이터가 없습니다.");
+            bool bootstrapSucceeded = false;
+            string bootstrapErrorMessage = "DB에 등록된 유저 데이터가 없습니다.";
+
+            yield return StartCoroutine(BootstrapMissingProfileCor(currentUser, (ok, message) =>
+            {
+                bootstrapSucceeded = ok;
+                bootstrapErrorMessage = message;
+            }));
+
+            if (!bootstrapSucceeded)
+            {
+                onCompleted?.Invoke(false, bootstrapErrorMessage);
+                yield break;
+            }
+
+            onCompleted?.Invoke(true, string.Empty);
             yield break;
         }
 
@@ -312,6 +327,37 @@ public class FirebaseAuthMgr : MonoBehaviour
         {
             profileData.skills = new List<PlayerSkillData>();
         }
+    }
+
+    private IEnumerator BootstrapMissingProfileCor(FirebaseUser currentUser, Action<bool, string> onCompleted)
+    {
+        if (_databaseRoot == null || currentUser == null)
+        {
+            onCompleted?.Invoke(false, "프로필 복구 준비가 완료되지 않았습니다.");
+            yield break;
+        }
+
+        string nickname = GetSafeNickname(currentUser);
+        var defaultProfile = PlayerProfileData.CreateDefault(currentUser.UserId, nickname);
+        string json = JsonUtility.ToJson(defaultProfile);
+
+        var saveTask = _databaseRoot.Child("users").Child(currentUser.UserId).SetRawJsonValueAsync(json);
+        yield return new WaitUntil(() => saveTask.IsCompleted);
+
+        if (saveTask.Exception != null)
+        {
+            Debug.LogWarning("누락된 프로필 자동 복구 실패 : " + saveTask.Exception);
+            onCompleted?.Invoke(false, "프로필 복구에 실패했습니다.");
+            yield break;
+        }
+
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.SetPlayerProfile(defaultProfile);
+        }
+
+        Debug.Log("[FirebaseAuthMgr] 누락된 유저 프로필 자동 복구 완료");
+        onCompleted?.Invoke(true, string.Empty);
     }
 
     private string GetSafeNickname(FirebaseUser currentUser)


### PR DESCRIPTION
### Motivation
- Prevent authenticated users from being locked out when their `users/<uid>` Realtime Database row is missing by restoring the previous self-healing bootstrap behavior.
- Ensure login only fails when automatic profile recreation itself fails, matching legacy behavior for migrated or legacy accounts.

### Description
- `LoadAndValidateProfileCor` now attempts an automatic recovery when `snapshot.Exists` is false by calling `BootstrapMissingProfileCor(...)` instead of failing immediately.
- Added `BootstrapMissingProfileCor(FirebaseUser, Action<bool,string>)` which creates a default profile via `PlayerProfileData.CreateDefault(...)`, serializes it with `JsonUtility.ToJson`, and writes it to `users/<uid>` using `SetRawJsonValueAsync`.
- The bootstrap coroutine sets the in-memory profile via `GameManager.Instance.SetPlayerProfile(...)` when the save succeeds and returns success to the caller so the login flow can continue.
- Login behavior was left unchanged except that missing DB rows are now auto-created and only cause failure if the create/save step fails.

### Testing
- Ran a code search for the new bootstrap path with `rg -n "BootstrapMissingProfileCor|!snapshot.Exists|SetRawJsonValueAsync\("` and confirmed the new function and branch are present, which succeeded.
- Inspected the updated diff and surrounding lines with `nl`/`sed` to verify `LoadAndValidateProfileCor` now calls `BootstrapMissingProfileCor` and that the bootstrap coroutine hydrates `GameManager` on success, which succeeded.
- Verified the save uses `SetRawJsonValueAsync` and that the flow returns success only after the write completes without exception, which was validated by the displayed diffs and checks and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985e33c77148330a57b432fc9864fbc)