### PR TITLE
feat: pre-generated run flow with RunManager, Room/InGame controllers, and reward UI

### DIFF
--- a/Assets/Scripts/Battle/BattleResult.cs
+++ b/Assets/Scripts/Battle/BattleResult.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class BattleResult
+{
+    public bool isWin;
+    public int remainingHp;
+    public List<RewardData> rewards = new List<RewardData>();
+}

--- a/Assets/Scripts/Core/RunFlowBootstrap.cs
+++ b/Assets/Scripts/Core/RunFlowBootstrap.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public static class RunFlowBootstrap
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void Bootstrap()
+    {
+        EnsureRunManager();
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        EnsureRunManager();
+
+        if (scene.name == "RoomScene")
+        {
+            if (Object.FindObjectOfType<RoomFlowController>() == null)
+            {
+                var go = new GameObject("RoomFlowController");
+                go.AddComponent<RoomFlowController>();
+            }
+
+            if (Object.FindObjectOfType<RoomSceneUI>() == null)
+            {
+                var go = new GameObject("RoomSceneUI");
+                go.AddComponent<RoomSceneUI>();
+            }
+        }
+
+        if (scene.name == "InGameScene")
+        {
+            if (Object.FindObjectOfType<InGameSceneController>() == null)
+            {
+                var go = new GameObject("InGameSceneController");
+                go.AddComponent<InGameSceneController>();
+            }
+        }
+    }
+
+    private static void EnsureRunManager()
+    {
+        if (RunManager.Instance != null)
+        {
+            return;
+        }
+
+        var go = new GameObject("RunManager");
+        go.AddComponent<RunManager>();
+    }
+}

--- a/Assets/Scripts/Core/RunManager.cs
+++ b/Assets/Scripts/Core/RunManager.cs
@@ -1,0 +1,181 @@
+using System;
+using UnityEngine;
+
+public class RunManager : MonoBehaviour
+{
+    public static RunManager Instance { get; private set; }
+
+    [SerializeField] private StatBlock startStats = new StatBlock
+    {
+        maxHp = 100,
+        currentHp = 100,
+        attack = 10,
+        defense = 0,
+        attackSpeed = 1,
+        critChance = 0,
+        critDamage = 150,
+    };
+
+    public event Action StateChanged;
+
+    public MetaProgress MetaProgress { get; private set; } = new MetaProgress();
+    public RunState RunState { get; private set; } = new RunState();
+    public StageRunData CurrentStageRun { get; private set; }
+
+    private bool _encounterLocked;
+
+    public bool HasActiveRun => CurrentStageRun != null && !RunState.isDead && !RunState.isCleared;
+
+    public EncounterData CurrentEncounter
+    {
+        get
+        {
+            if (_encounterLocked || CurrentStageRun == null)
+            {
+                return null;
+            }
+
+            return CurrentStageRun.GetCurrentEncounter();
+        }
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public void StartNewRun(int stageId, int totalDays, int seed)
+    {
+        RunState.StartRun(startStats);
+        CurrentStageRun = StageGenerator.Generate(stageId, totalDays, seed);
+        _encounterLocked = false;
+        NotifyStateChanged();
+    }
+
+    public void ApplyReward(RewardData reward)
+    {
+        if (reward == null || RunState == null)
+        {
+            return;
+        }
+
+        switch (reward.rewardType)
+        {
+            case RewardType.Heal:
+                RunState.stats.Heal(reward.amount);
+                break;
+            case RewardType.Gold:
+                RunState.currentGold += reward.amount;
+                break;
+            case RewardType.Stat:
+                RunState.stats.AddStat(reward.statType, reward.amount);
+                break;
+            case RewardType.Skill:
+                if (!string.IsNullOrEmpty(reward.skillId) && !RunState.ownedSkillIds.Contains(reward.skillId))
+                {
+                    RunState.ownedSkillIds.Add(reward.skillId);
+                }
+                break;
+            case RewardType.Item:
+                if (!string.IsNullOrEmpty(reward.itemId) && !RunState.ownedItemIds.Contains(reward.itemId))
+                {
+                    RunState.ownedItemIds.Add(reward.itemId);
+                }
+                break;
+            case RewardType.Exp:
+                break;
+        }
+
+        NotifyStateChanged();
+    }
+
+    public void ApplyRewards(System.Collections.Generic.IEnumerable<RewardData> rewards)
+    {
+        if (rewards == null)
+        {
+            return;
+        }
+
+        foreach (var reward in rewards)
+        {
+            ApplyReward(reward);
+        }
+    }
+
+    public void SetCurrentHp(int currentHp)
+    {
+        if (RunState == null || RunState.stats == null)
+        {
+            return;
+        }
+
+        RunState.stats.currentHp = Mathf.Clamp(currentHp, 0, RunState.stats.maxHp);
+        NotifyStateChanged();
+    }
+
+    public void AdvanceDay()
+    {
+        if (CurrentStageRun == null)
+        {
+            return;
+        }
+
+        CurrentStageRun.AdvanceDay();
+        RunState.AdvanceDay();
+        NotifyStateChanged();
+    }
+
+    public bool IsLastDay()
+    {
+        return CurrentStageRun != null && CurrentStageRun.IsLastDay();
+    }
+
+    public void MarkDead()
+    {
+        RunState.MarkDead();
+        NotifyStateChanged();
+    }
+
+    public void MarkCleared()
+    {
+        RunState.MarkCleared();
+        NotifyStateChanged();
+    }
+
+    public void FinalizeRun()
+    {
+        if (RunState != null)
+        {
+            MetaProgress.totalGold += RunState.currentGold;
+            MetaProgress.highestDay = Mathf.Max(MetaProgress.highestDay, RunState.currentDay);
+        }
+
+        CurrentStageRun = null;
+        _encounterLocked = false;
+        NotifyStateChanged();
+    }
+
+    public void ClearEncounter()
+    {
+        _encounterLocked = true;
+        NotifyStateChanged();
+    }
+
+    public void UnlockEncounter()
+    {
+        _encounterLocked = false;
+        NotifyStateChanged();
+    }
+
+    private void NotifyStateChanged()
+    {
+        StateChanged?.Invoke();
+    }
+}

--- a/Assets/Scripts/Data/EncounterData.cs
+++ b/Assets/Scripts/Data/EncounterData.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class EncounterData
+{
+    public string encounterId;
+    public EncounterType encounterType;
+    public int day;
+    public string enemyId;
+    public bool hasSelectionReward;
+    public List<RewardData> rewards = new List<RewardData>();
+}

--- a/Assets/Scripts/Data/Enums/EncounterType.cs
+++ b/Assets/Scripts/Data/Enums/EncounterType.cs
@@ -1,0 +1,8 @@
+public enum EncounterType
+{
+    Battle,
+    Reward,
+    Rest,
+    Boss,
+    Event,
+}

--- a/Assets/Scripts/Data/Enums/RewardType.cs
+++ b/Assets/Scripts/Data/Enums/RewardType.cs
@@ -1,0 +1,9 @@
+public enum RewardType
+{
+    Heal,
+    Gold,
+    Skill,
+    Item,
+    Exp,
+    Stat,
+}

--- a/Assets/Scripts/Data/Enums/StatType.cs
+++ b/Assets/Scripts/Data/Enums/StatType.cs
@@ -1,0 +1,9 @@
+public enum StatType
+{
+    MaxHp,
+    Attack,
+    Defense,
+    AttackSpeed,
+    CritChance,
+    CritDamage,
+}

--- a/Assets/Scripts/Data/Reward.cs
+++ b/Assets/Scripts/Data/Reward.cs
@@ -1,5 +1,5 @@
 ﻿
-public enum RewardType
+public enum LegacyRewardType
 {
     Skill = 0, // 스킬 보상
     Gold = 1, // 골드 보상
@@ -14,10 +14,10 @@ public class Reward
     public string name; // 보상 이름
     public string description; // 보상 설명
     public int amount; // 보상 수량
-    public RewardType type; // 보상 타입 (0: 스킬, 1: 골드, 2: 경험치, 3: 스텟(공,방))
+    public LegacyRewardType type; // 보상 타입 (0: 스킬, 1: 골드, 2: 경험치, 3: 스텟(공,방))
     public int value; // 보상 값 (아이템 ID, 골드 양, 경험치 양 등)
     public bool isClaimed; // 보상 수령 여부
-    public Reward(int id, string name, string description, int amount, RewardType type, int value)
+    public Reward(int id, string name, string description, int amount, LegacyRewardType type, int value)
     {
         this.id = id;
         this.name = name;
@@ -28,4 +28,3 @@ public class Reward
         this.isClaimed = false;
     }
 }
-

--- a/Assets/Scripts/Data/RewardData.cs
+++ b/Assets/Scripts/Data/RewardData.cs
@@ -1,0 +1,36 @@
+using System;
+
+[Serializable]
+public class RewardData
+{
+    public RewardType rewardType;
+    public int amount;
+    public StatType statType;
+    public string skillId;
+    public string itemId;
+
+    public static RewardData CreateHeal(int amount)
+    {
+        return new RewardData { rewardType = RewardType.Heal, amount = amount };
+    }
+
+    public static RewardData CreateGold(int amount)
+    {
+        return new RewardData { rewardType = RewardType.Gold, amount = amount };
+    }
+
+    public static RewardData CreateStat(StatType statType, int amount)
+    {
+        return new RewardData { rewardType = RewardType.Stat, statType = statType, amount = amount };
+    }
+
+    public static RewardData CreateSkill(string skillId)
+    {
+        return new RewardData { rewardType = RewardType.Skill, skillId = skillId };
+    }
+
+    public static RewardData CreateItem(string itemId)
+    {
+        return new RewardData { rewardType = RewardType.Item, itemId = itemId };
+    }
+}

--- a/Assets/Scripts/InGame/InGameSceneController.cs
+++ b/Assets/Scripts/InGame/InGameSceneController.cs
@@ -1,0 +1,169 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+public class InGameSceneController : MonoBehaviour
+{
+    [SerializeField] private BattleManager battleManager;
+    [SerializeField] private RewardSelectUI rewardSelectUI;
+    [SerializeField] private Text resultText;
+    [SerializeField] private float returnDelay = 0.6f;
+
+    private EncounterData _encounter;
+
+    private void Start()
+    {
+        EnsureRuntimeRefs();
+
+        var runManager = RunManager.Instance;
+        if (runManager == null)
+        {
+            ReturnToRoom();
+            return;
+        }
+
+        _encounter = runManager.CurrentEncounter;
+        if (_encounter == null)
+        {
+            ReturnToRoom();
+            return;
+        }
+
+        ExecuteEncounter(_encounter);
+    }
+
+    private void EnsureRuntimeRefs()
+    {
+        if (battleManager == null)
+        {
+            battleManager = FindObjectOfType<BattleManager>();
+        }
+
+        if (rewardSelectUI == null)
+        {
+            rewardSelectUI = FindObjectOfType<RewardSelectUI>();
+        }
+
+        if (rewardSelectUI == null)
+        {
+            var rewardUiObject = new GameObject("RewardSelectUI");
+            rewardSelectUI = rewardUiObject.AddComponent<RewardSelectUI>();
+        }
+    }
+
+    private void ExecuteEncounter(EncounterData encounter)
+    {
+        switch (encounter.encounterType)
+        {
+            case EncounterType.Rest:
+            case EncounterType.Event:
+                SetResult("Reward Applied");
+                RunManager.Instance.ApplyRewards(encounter.rewards);
+                StartCoroutine(CompleteEncounterSuccess());
+                break;
+            case EncounterType.Reward:
+                HandleRewardEncounter(encounter);
+                break;
+            case EncounterType.Battle:
+            case EncounterType.Boss:
+                if (battleManager == null)
+                {
+                    battleManager = FindObjectOfType<BattleManager>();
+                }
+
+                if (battleManager == null)
+                {
+                    SetResult("BattleManager Missing");
+                    RunManager.Instance.MarkDead();
+                    StartCoroutine(ReturnToRoomRoutine());
+                    return;
+                }
+
+                SetResult("Battle Start");
+                battleManager.StartEncounterBattle(encounter, this);
+                break;
+        }
+    }
+
+    private void HandleRewardEncounter(EncounterData encounter)
+    {
+        if (encounter.hasSelectionReward && rewardSelectUI != null && encounter.rewards != null && encounter.rewards.Count > 0)
+        {
+            SetResult("Select Reward");
+            rewardSelectUI.Show(encounter.rewards, OnSelectedReward);
+            return;
+        }
+
+        SetResult("Reward Applied");
+        RunManager.Instance.ApplyRewards(encounter.rewards);
+        StartCoroutine(CompleteEncounterSuccess());
+    }
+
+    private void OnSelectedReward(RewardData reward)
+    {
+        RunManager.Instance.ApplyReward(reward);
+        StartCoroutine(CompleteEncounterSuccess());
+    }
+
+    public void OnBattleFinished(BattleResult result)
+    {
+        if (result == null)
+        {
+            RunManager.Instance.MarkDead();
+            StartCoroutine(ReturnToRoomRoutine());
+            return;
+        }
+
+        RunManager.Instance.SetCurrentHp(result.remainingHp);
+
+        if (!result.isWin)
+        {
+            SetResult("Defeat");
+            RunManager.Instance.MarkDead();
+            StartCoroutine(ReturnToRoomRoutine());
+            return;
+        }
+
+        SetResult("Victory");
+        RunManager.Instance.ApplyRewards(result.rewards);
+        StartCoroutine(CompleteEncounterSuccess());
+    }
+
+    private IEnumerator CompleteEncounterSuccess()
+    {
+        bool isLastDay = RunManager.Instance.IsLastDay();
+        RunManager.Instance.ClearEncounter();
+
+        if (isLastDay)
+        {
+            RunManager.Instance.MarkCleared();
+        }
+        else
+        {
+            RunManager.Instance.AdvanceDay();
+        }
+
+        yield return new WaitForSeconds(returnDelay);
+        ReturnToRoom();
+    }
+
+    private IEnumerator ReturnToRoomRoutine()
+    {
+        yield return new WaitForSeconds(returnDelay);
+        ReturnToRoom();
+    }
+
+    private void ReturnToRoom()
+    {
+        SceneManager.LoadScene("RoomScene");
+    }
+
+    private void SetResult(string message)
+    {
+        if (resultText != null)
+        {
+            resultText.text = message;
+        }
+    }
+}

--- a/Assets/Scripts/InGame/RewardSelectUI.cs
+++ b/Assets/Scripts/InGame/RewardSelectUI.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class RewardSelectUI : MonoBehaviour
+{
+    [SerializeField] private GameObject rootPanel;
+    [SerializeField] private Text titleText;
+    [SerializeField] private Button[] optionButtons;
+    [SerializeField] private Text[] optionTexts;
+
+    private Action<RewardData> _onSelected;
+    private List<RewardData> _currentRewards;
+
+    private void Awake()
+    {
+        EnsureRuntimeUI();
+        Hide();
+    }
+
+    public void Show(List<RewardData> rewards, Action<RewardData> onSelected)
+    {
+        _currentRewards = rewards;
+        _onSelected = onSelected;
+
+        if (titleText != null)
+        {
+            titleText.text = "Choose Reward";
+        }
+
+        if (rootPanel != null)
+        {
+            rootPanel.SetActive(true);
+        }
+
+        for (int i = 0; i < optionButtons.Length; i++)
+        {
+            var button = optionButtons[i];
+            var text = i < optionTexts.Length ? optionTexts[i] : null;
+            if (button == null)
+            {
+                continue;
+            }
+
+            int index = i;
+            button.onClick.RemoveAllListeners();
+
+            bool hasReward = rewards != null && index < rewards.Count;
+            button.gameObject.SetActive(hasReward);
+            button.interactable = hasReward;
+
+            if (text != null)
+            {
+                text.text = hasReward ? BuildRewardLabel(rewards[index]) : string.Empty;
+            }
+
+            if (hasReward)
+            {
+                button.onClick.AddListener(delegate { Select(index); });
+            }
+        }
+    }
+
+    public void Hide()
+    {
+        if (rootPanel != null)
+        {
+            rootPanel.SetActive(false);
+        }
+    }
+
+    public static string BuildRewardLabel(RewardData reward)
+    {
+        if (reward == null)
+        {
+            return "None";
+        }
+
+        switch (reward.rewardType)
+        {
+            case RewardType.Heal:
+                return "Heal +" + reward.amount;
+            case RewardType.Gold:
+                return "Gold +" + reward.amount;
+            case RewardType.Stat:
+                return reward.statType + " +" + reward.amount;
+            case RewardType.Skill:
+                return "Skill " + reward.skillId;
+            case RewardType.Item:
+                return "Item " + reward.itemId;
+            case RewardType.Exp:
+                return "Exp +" + reward.amount;
+            default:
+                return reward.rewardType.ToString();
+        }
+    }
+
+    private void Select(int index)
+    {
+        if (_currentRewards == null || index < 0 || index >= _currentRewards.Count)
+        {
+            return;
+        }
+
+        var selected = _currentRewards[index];
+        Hide();
+        _onSelected?.Invoke(selected);
+    }
+
+    private void EnsureRuntimeUI()
+    {
+        if (optionButtons != null && optionButtons.Length > 0 && rootPanel != null)
+        {
+            return;
+        }
+
+        Canvas canvas = FindObjectOfType<Canvas>();
+        if (canvas == null)
+        {
+            var canvasObject = new GameObject("InGameCanvas");
+            canvas = canvasObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasObject.AddComponent<CanvasScaler>();
+            canvasObject.AddComponent<GraphicRaycaster>();
+        }
+
+        rootPanel = new GameObject("RewardSelectPanel");
+        rootPanel.transform.SetParent(canvas.transform, false);
+        var layout = rootPanel.AddComponent<VerticalLayoutGroup>();
+        layout.childControlHeight = true;
+        layout.childControlWidth = true;
+
+        titleText = CreateText("RewardTitle", rootPanel.transform, "Choose Reward");
+        optionButtons = new Button[3];
+        optionTexts = new Text[3];
+
+        for (int i = 0; i < 3; i++)
+        {
+            var buttonObject = new GameObject("RewardOption" + i);
+            buttonObject.transform.SetParent(rootPanel.transform, false);
+            buttonObject.AddComponent<Image>();
+            var button = buttonObject.AddComponent<Button>();
+            var label = CreateText("Label", buttonObject.transform, string.Empty);
+            label.alignment = TextAnchor.MiddleCenter;
+            optionButtons[i] = button;
+            optionTexts[i] = label;
+        }
+    }
+
+    private Text CreateText(string objectName, Transform parent, string value)
+    {
+        var textObject = new GameObject(objectName);
+        textObject.transform.SetParent(parent, false);
+        var text = textObject.AddComponent<Text>();
+        text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        text.color = Color.white;
+        text.fontSize = 24;
+        text.text = value;
+        return text;
+    }
+}

--- a/Assets/Scripts/Manager/BattleManager.cs
+++ b/Assets/Scripts/Manager/BattleManager.cs
@@ -1,9 +1,7 @@
-// BattleManager.cs
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class BattleManager : MonoBehaviour
 {
@@ -12,11 +10,9 @@ public class BattleManager : MonoBehaviour
     [SerializeField] private Transform monsterTransform;
     [SerializeField] private ParallaxBackground parallaxBackground;
     [SerializeField] private GameObject LogUIObj;
-    [SerializeField] private StageManager stageManager;
-    [SerializeField] private EncounterManager encounterManager;
 
     [Header("Timing")]
-    [SerializeField] private float moveDuration = 5.5f;
+    [SerializeField] private float moveDuration = 1.2f;
     [SerializeField] private float attackDelay = 0.5f;
 
     private LogUI _logUI;
@@ -26,24 +22,22 @@ public class BattleManager : MonoBehaviour
     private ICombatant _monsterStats;
     private Queue<ICombatant> _turnQueue;
     private Animator _monsterAnimator;
-    private MonsterDefinition _currentMonsterDefinition;
     private bool _playerHpBound;
-
-    Coroutine combat = null;
+    private UnitStats _runtimePlayerStats;
+    private EncounterData _currentEncounter;
+    private InGameSceneController _sceneController;
 
     private void Awake()
     {
-        _logUI = LogUIObj.GetComponent<LogUI>();
-    }
+        if (LogUIObj != null)
+        {
+            _logUI = LogUIObj.GetComponent<LogUI>();
+        }
 
-
-    private void Start()
-    {
-        // 컴포넌트 & 스탯 초기화
-        EnsureManagerReferences();
-        _player = playerTransform.GetComponent<Player>();
-        _playerStats = _player.GetStats();
-        combat = StartCoroutine(StartBattleSequence());
+        if (playerTransform != null)
+        {
+            _player = playerTransform.GetComponent<Player>();
+        }
     }
 
     private void OnDestroy()
@@ -51,6 +45,7 @@ public class BattleManager : MonoBehaviour
         if (_playerHpBound && _playerStats != null)
         {
             _playerStats.OnHpChanged -= OnPlayerHpChanged;
+            _playerHpBound = false;
         }
 
         if (_monsterStats != null)
@@ -59,196 +54,120 @@ public class BattleManager : MonoBehaviour
         }
     }
 
-    private void EnsureManagerReferences()
+    public void StartEncounterBattle(EncounterData encounterData, InGameSceneController sceneController)
     {
-        if (stageManager == null)
-            stageManager = StageManager.Instance;
+        if (encounterData == null)
+        {
+            sceneController?.OnBattleFinished(new BattleResult { isWin = false });
+            return;
+        }
 
-        if (encounterManager == null)
-            encounterManager = EncounterManager.Instance;
+        _currentEncounter = encounterData;
+        _sceneController = sceneController;
+
+        StopAllCoroutines();
+        StartCoroutine(StartBattleSequence());
     }
 
     private IEnumerator StartBattleSequence()
     {
-        Debug.Log("전투 시작 시퀀스 시작");
-        EnsureManagerReferences();
-
-        if (stageManager == null)
+        if (_player == null && playerTransform != null)
         {
-            yield return new WaitUntil(() => StageManager.Instance != null);
-            stageManager = StageManager.Instance;
+            _player = playerTransform.GetComponent<Player>();
         }
 
-        if (encounterManager == null)
+        if (_player == null)
         {
-            yield return new WaitUntil(() => EncounterManager.Instance != null);
-            encounterManager = EncounterManager.Instance;
-        }
-
-        if (!PrepareMonsterForToday())
-        {
+            _sceneController?.OnBattleFinished(new BattleResult { isWin = false });
             yield break;
         }
 
-        if (UIManager.Instance == null)
-            yield return new WaitUntil(() => UIManager.Instance != null);
-        // HP 변경 UI 바인딩
+        BuildPlayerStats();
+
+        if (!PrepareMonsterForEncounter(_currentEncounter))
+        {
+            _sceneController?.OnBattleFinished(new BattleResult { isWin = false, remainingHp = RunManager.Instance.RunState.stats.currentHp });
+            yield break;
+        }
+
         BindHpEvents();
 
-        Debug.Log("전투 시작 시퀀스");
+        if (_logUI != null)
+        {
+            _logUI.AddDayLog(_currentEncounter.day, "Battle Start");
+        }
 
-        // 전투 시작 로그
-        int currentDay = stageManager != null ? stageManager.CurrentDay : 0;
-        _logUI.AddDayLog(currentDay, "전투 시작!");
+        if (playerTransform != null)
+        {
+            yield return MoveOverTime(playerTransform, playerTransform.position, playerTransform.position + Vector3.right * 1f, moveDuration);
+        }
 
-        Debug.Log(playerTransform.gameObject.name);
-
-        // 연출 플레이어/몬스터 접근
-        yield return MoveOverTime(playerTransform, playerTransform.position,
-                                 playerTransform.position + Vector3.right * 1f, moveDuration);
-
-        Debug.Log(monsterTransform.gameObject.name);
-
-        var monsterStart = monsterTransform.position + Vector3.right * 2.5f;
-
-        yield return MoveOverTime(monsterTransform, monsterStart,
-                                 monsterStart + Vector3.left * 3.5f, moveDuration);
+        if (monsterTransform != null)
+        {
+            var monsterStart = monsterTransform.position + Vector3.right * 2.5f;
+            yield return MoveOverTime(monsterTransform, monsterStart, monsterStart + Vector3.left * 3.5f, moveDuration);
+        }
 
         yield return new WaitForSeconds(attackDelay);
-        parallaxBackground.cameraMove = false;
 
-        // 턴 큐 초기화 & 전투 루프 시작
+        if (parallaxBackground != null)
+        {
+            parallaxBackground.cameraMove = false;
+        }
+
         InitTurnQueue();
-        StartCoroutine(CombatLoop());
+        yield return CombatLoop();
     }
 
-    private void InitTurnQueue()
+    private void BuildPlayerStats()
     {
-        // 속도 내림차순 정렬 후 큐에 넣기
-        var ordered = new List<ICombatant> { _playerStats, _monsterStats }
-                      .OrderByDescending(u => u.Speed);
-        _turnQueue = new Queue<ICombatant>(ordered);
+        var runStats = RunManager.Instance != null ? RunManager.Instance.RunState.stats : null;
+        if (runStats == null)
+        {
+            _runtimePlayerStats = _player.GetStats() as UnitStats;
+            _playerStats = _runtimePlayerStats;
+            return;
+        }
+
+        int speed = Mathf.Max(1, runStats.attackSpeed);
+        _runtimePlayerStats = new UnitStats("Player", runStats.maxHp, runStats.attack, speed, 1);
+        int missingHp = runStats.maxHp - runStats.currentHp;
+        if (missingHp > 0)
+        {
+            _runtimePlayerStats.TakeDamage(missingHp);
+        }
+
+        _playerStats = _runtimePlayerStats;
     }
 
-    private IEnumerator CombatLoop()
+    private bool PrepareMonsterForEncounter(EncounterData encounterData)
     {
-        while (_turnQueue.Count > 0)
-        {
-            var actor = _turnQueue.Dequeue();
-            var defender = actor == _playerStats ? _monsterStats : _playerStats;
-
-            if (actor.IsDead)
-                continue;
-
-            actor.ResetActions();
-
-            // 남은 행동만큼 반복
-            while (actor.ActionsRemaining > 0 && !defender.IsDead)
-            {
-                // 공격 애니메이션
-                if (actor == _playerStats)
-                {
-                    _player.SetAnim(PlayerState.ATTACK);
-                }
-                else PlayMonsterAnimation(MonsterState.Atk1);
-
-
-
-                // 피해 적용
-                defender.TakeDamage(actor.Attack);
-                _logUI.AddLog($"{actor.Name} → {defender.Name} : {actor.Attack} 피해");
-
-                actor.ActionsRemaining--;
-                yield return new WaitForSeconds(attackDelay);
-            }
-
-            // 사망 처리
-            if (defender.IsDead)
-            {
-                yield return HandleDeath(defender);
-
-                yield break;
-            }
-
-            // 다시 큐에 넣기
-            if (!actor.IsDead)
-                _turnQueue.Enqueue(actor);
-
-            yield return new WaitForSeconds(attackDelay);
-        }
-    }
-
-
-    private IEnumerator EndBattleRoutine()
-    {
-        EnsureManagerReferences();
-
-        if (stageManager != null)
-        {
-            stageManager.AdvanceDay();
-            _logUI.AddDayLog(stageManager.CurrentDay, $"Stage {stageManager.CurrentStage}");
-        }
-        else
-        {
-            Debug.LogWarning("BattleManager: StageManager reference missing when ending battle.");
-        }
-
-        combat = StartCoroutine(StartBattleSequence());
-        yield return null;
-    }
-
-    private IEnumerator HandleDeath(ICombatant fallen)
-    {
-        if (fallen == _playerStats)
-        {
-            _player.SetAnim(PlayerState.DEATH);
-            _logUI.AddLog("YOU DIED");
-
-            yield return new WaitForSeconds(1f);
-
-            SceneManager.LoadScene(nameof(SceneNames.RoomScene));
-        }
-        else
-        {
-            PlayMonsterAnimation(MonsterState.Death);
-            _logUI.AddLog($"{fallen.Name} 처치!");
-
-            yield return new WaitForSeconds(1f);
-
-            DestroyCurrentMonster();
-            parallaxBackground.cameraMove = true;
-            yield return EndBattleRoutine();
-        }
-    }
-
-    private bool PrepareMonsterForToday()
-    {
-        if (encounterManager == null)
-        {
-            Debug.LogWarning("BattleManager: EncounterManager reference is missing.");
-            return false;
-        }
-
-        var encounters = encounterManager.GetRandomEncounters(1);
-        if (encounters == null || encounters.Count == 0)
-        {
-            Debug.LogWarning("BattleManager: No monster definitions available for today's encounter.");
-            return false;
-        }
-
-        var monsterDefinition = encounters[0];
-        if (monsterDefinition == null)
-        {
-            Debug.LogWarning("BattleManager: EncounterManager returned a null MonsterDefinition.");
-            return false;
-        }
-
         ClearExistingMonster();
 
-        MonsterBase spawned = MonsterFactory.Spawn(monsterDefinition, monsterTransform, Vector3.zero);
+        var candidates = Resources.LoadAll<MonsterDefinition>("");
+        if (candidates == null || candidates.Length == 0)
+        {
+            return false;
+        }
+
+        int index = Mathf.Abs((encounterData.day * 7) + encounterData.encounterType.GetHashCode()) % candidates.Length;
+        var selected = candidates[index];
+        if (selected == null || selected.prefab == null)
+        {
+            return false;
+        }
+
+        MonsterDefinition runtimeDef = ScriptableObject.CreateInstance<MonsterDefinition>();
+        runtimeDef.monsterName = selected.monsterName;
+        runtimeDef.prefab = selected.prefab;
+        runtimeDef.maxHp = selected.maxHp + (encounterData.day * (encounterData.encounterType == EncounterType.Boss ? 20 : 8));
+        runtimeDef.attack = selected.attack + (encounterData.day * (encounterData.encounterType == EncounterType.Boss ? 3 : 1));
+        runtimeDef.speed = Mathf.Max(1, selected.speed);
+        runtimeDef.attackCount = Mathf.Max(1, selected.attackCount);
+
+        MonsterBase spawned = MonsterFactory.Spawn(runtimeDef, monsterTransform, Vector3.zero);
         if (spawned == null)
         {
-            Debug.LogError("BattleManager: Failed to spawn monster from definition.");
             return false;
         }
 
@@ -260,9 +179,115 @@ public class BattleManager : MonoBehaviour
             _monsterAnimator = spawned.GetComponentInChildren<Animator>();
         }
 
-        _currentMonsterDefinition = monsterDefinition;
-
         return true;
+    }
+
+    private void InitTurnQueue()
+    {
+        var ordered = new List<ICombatant> { _playerStats, _monsterStats }.OrderByDescending(u => u.Speed);
+        _turnQueue = new Queue<ICombatant>(ordered);
+    }
+
+    private IEnumerator CombatLoop()
+    {
+        while (_turnQueue.Count > 0)
+        {
+            var actor = _turnQueue.Dequeue();
+            var defender = actor == _playerStats ? _monsterStats : _playerStats;
+
+            if (actor.IsDead)
+            {
+                continue;
+            }
+
+            actor.ResetActions();
+
+            while (actor.ActionsRemaining > 0 && !defender.IsDead)
+            {
+                if (actor == _playerStats)
+                {
+                    _player.SetAnim(PlayerState.ATTACK);
+                }
+                else
+                {
+                    PlayMonsterAnimation(MonsterState.Atk1);
+                }
+
+                defender.TakeDamage(actor.Attack);
+                if (_logUI != null)
+                {
+                    _logUI.AddLog(actor.Name + " -> " + defender.Name + " : " + actor.Attack);
+                }
+
+                actor.ActionsRemaining--;
+                yield return new WaitForSeconds(attackDelay);
+            }
+
+            if (defender.IsDead)
+            {
+                yield return HandleDeath(defender);
+                yield break;
+            }
+
+            if (!actor.IsDead)
+            {
+                _turnQueue.Enqueue(actor);
+            }
+
+            yield return new WaitForSeconds(attackDelay);
+        }
+    }
+
+    private IEnumerator HandleDeath(ICombatant fallen)
+    {
+        if (fallen == _playerStats)
+        {
+            _player.SetAnim(PlayerState.DEATH);
+            if (_logUI != null)
+            {
+                _logUI.AddLog("Defeat");
+            }
+
+            yield return new WaitForSeconds(1f);
+            ReportBattleFinished(false);
+        }
+        else
+        {
+            PlayMonsterAnimation(MonsterState.Death);
+            if (_logUI != null)
+            {
+                _logUI.AddLog("Victory");
+            }
+
+            yield return new WaitForSeconds(1f);
+            DestroyCurrentMonster();
+
+            if (parallaxBackground != null)
+            {
+                parallaxBackground.cameraMove = true;
+            }
+
+            ReportBattleFinished(true);
+        }
+    }
+
+    private void ReportBattleFinished(bool isWin)
+    {
+        var result = new BattleResult
+        {
+            isWin = isWin,
+            remainingHp = _runtimePlayerStats != null ? _runtimePlayerStats.CurrentHp : 0,
+            rewards = isWin && _currentEncounter != null && _currentEncounter.rewards != null
+                ? new List<RewardData>(_currentEncounter.rewards)
+                : new List<RewardData>(),
+        };
+
+        if (RunManager.Instance != null)
+        {
+            RunManager.Instance.SetCurrentHp(result.remainingHp);
+        }
+
+        _sceneController?.OnBattleFinished(result);
     }
 
     private void ClearExistingMonster()
@@ -275,7 +300,11 @@ public class BattleManager : MonoBehaviour
 
         _monster = null;
         _monsterAnimator = null;
-        _currentMonsterDefinition = null;
+
+        if (monsterTransform == null)
+        {
+            return;
+        }
 
         for (int i = monsterTransform.childCount - 1; i >= 0; i--)
         {
@@ -301,17 +330,7 @@ public class BattleManager : MonoBehaviour
             _monster = null;
         }
 
-        for (int i = monsterTransform.childCount - 1; i >= 0; i--)
-        {
-            var child = monsterTransform.GetChild(i);
-            if (child != null)
-            {
-                Destroy(child.gameObject);
-            }
-        }
-
         _monsterAnimator = null;
-        _currentMonsterDefinition = null;
     }
 
     private void BindHpEvents()
@@ -320,34 +339,32 @@ public class BattleManager : MonoBehaviour
         {
             _playerStats.OnHpChanged += OnPlayerHpChanged;
             _playerHpBound = true;
-
-            if (UIManager.Instance != null && _playerStats is UnitStats playerStats)
+            if (_runtimePlayerStats != null)
             {
-                UIManager.Instance.UpdatePlayerHp(playerStats.CurrentHp, playerStats.MaxHp);
+                OnPlayerHpChanged(_runtimePlayerStats.CurrentHp, _runtimePlayerStats.MaxHp);
             }
         }
 
         if (_monsterStats != null)
         {
             _monsterStats.OnHpChanged += OnMonsterHpChanged;
-
-            if (UIManager.Instance != null && _currentMonsterDefinition != null)
-            {
-                UIManager.Instance.UpdateMonsterHp(_currentMonsterDefinition.maxHp, _currentMonsterDefinition.maxHp);
-            }
         }
     }
 
     private void OnPlayerHpChanged(int currentHp, int maxHp)
     {
         if (UIManager.Instance != null)
+        {
             UIManager.Instance.UpdatePlayerHp(currentHp, maxHp);
+        }
     }
 
     private void OnMonsterHpChanged(int currentHp, int maxHp)
     {
         if (UIManager.Instance != null)
+        {
             UIManager.Instance.UpdateMonsterHp(currentHp, maxHp);
+        }
     }
 
     private void PlayMonsterAnimation(MonsterState state)
@@ -367,6 +384,7 @@ public class BattleManager : MonoBehaviour
             elapsed += Time.deltaTime;
             yield return null;
         }
+
         t.position = to;
     }
 }

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
+
 public enum SceneName
 {
     TitleScene,
@@ -9,13 +10,10 @@ public enum SceneName
 
 public class GameManager : MonoBehaviour
 {
-
     public static GameManager Instance { get; set; }
 
     public Player PlayerState;
     public PlayerProfileData PlayerProfile { get; private set; }
-
-    public int CurrentDay = 1; // 현재 날짜
 
     private void Awake()
     {

--- a/Assets/Scripts/Room/RoomFlowController.cs
+++ b/Assets/Scripts/Room/RoomFlowController.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class RoomFlowController : MonoBehaviour
+{
+    [SerializeField] private int stageId = 1;
+    [SerializeField] private int totalDays = 5;
+    [SerializeField] private int seed = 0;
+
+    public EncounterData NextEncounter => RunManager.Instance != null ? RunManager.Instance.CurrentEncounter : null;
+
+    private void Start()
+    {
+        if (RunManager.Instance == null)
+        {
+            Debug.LogError("RoomFlowController: RunManager is missing.");
+            return;
+        }
+
+        if (!RunManager.Instance.HasActiveRun)
+        {
+            int runSeed = seed == 0 ? System.Environment.TickCount : seed;
+            RunManager.Instance.StartNewRun(stageId, totalDays, runSeed);
+        }
+        else
+        {
+            RunManager.Instance.UnlockEncounter();
+        }
+    }
+
+    public void EnterEncounter()
+    {
+        if (RunManager.Instance == null || RunManager.Instance.CurrentEncounter == null)
+        {
+            return;
+        }
+
+        SceneManager.LoadScene("InGameScene");
+    }
+
+    public void RegenerateNextEncounter()
+    {
+        Debug.Log("RoomFlowController: RegenerateNextEncounter disabled in pre-generated mode.");
+    }
+}

--- a/Assets/Scripts/Room/RoomSceneUI.cs
+++ b/Assets/Scripts/Room/RoomSceneUI.cs
@@ -1,0 +1,213 @@
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class RoomSceneUI : MonoBehaviour
+{
+    [SerializeField] private RoomFlowController roomFlowController;
+    [SerializeField] private Text dayText;
+    [SerializeField] private Text hpText;
+    [SerializeField] private Text goldText;
+    [SerializeField] private Text attackText;
+    [SerializeField] private Text encounterTypeText;
+    [SerializeField] private Text encounterRewardText;
+    [SerializeField] private Button enterButton;
+    [SerializeField] private Button rerollButton;
+
+    private void OnEnable()
+    {
+        EnsureRuntimeUI();
+
+        if (enterButton != null)
+        {
+            enterButton.onClick.AddListener(OnEnterClicked);
+        }
+
+        if (rerollButton != null)
+        {
+            rerollButton.onClick.AddListener(OnRerollClicked);
+            rerollButton.interactable = false;
+        }
+
+        if (RunManager.Instance != null)
+        {
+            RunManager.Instance.StateChanged += Refresh;
+        }
+
+        Refresh();
+    }
+
+    private void EnsureRuntimeUI()
+    {
+        if (roomFlowController == null)
+        {
+            roomFlowController = FindObjectOfType<RoomFlowController>();
+        }
+
+        if (dayText != null && enterButton != null)
+        {
+            return;
+        }
+
+        Canvas canvas = FindObjectOfType<Canvas>();
+        if (canvas == null)
+        {
+            var canvasObject = new GameObject("RunFlowCanvas");
+            canvas = canvasObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasObject.AddComponent<CanvasScaler>();
+            canvasObject.AddComponent<GraphicRaycaster>();
+        }
+
+        var panelObject = new GameObject("RunHudPanel");
+        panelObject.transform.SetParent(canvas.transform, false);
+        var panel = panelObject.AddComponent<VerticalLayoutGroup>();
+        panel.childControlHeight = true;
+        panel.childControlWidth = true;
+        panel.childForceExpandHeight = false;
+        panel.childForceExpandWidth = true;
+
+        dayText = CreateText("DayText", panelObject.transform);
+        hpText = CreateText("HpText", panelObject.transform);
+        goldText = CreateText("GoldText", panelObject.transform);
+        attackText = CreateText("AttackText", panelObject.transform);
+        encounterTypeText = CreateText("EncounterTypeText", panelObject.transform);
+        encounterRewardText = CreateText("EncounterRewardText", panelObject.transform);
+
+        enterButton = CreateButton("EnterButton", "Enter Encounter", panelObject.transform);
+        rerollButton = CreateButton("RerollButton", "Reroll Disabled", panelObject.transform);
+    }
+
+    private Text CreateText(string objectName, Transform parent)
+    {
+        var textObject = new GameObject(objectName);
+        textObject.transform.SetParent(parent, false);
+        var text = textObject.AddComponent<Text>();
+        text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        text.color = Color.white;
+        text.fontSize = 24;
+        return text;
+    }
+
+    private Button CreateButton(string objectName, string label, Transform parent)
+    {
+        var buttonObject = new GameObject(objectName);
+        buttonObject.transform.SetParent(parent, false);
+        var image = buttonObject.AddComponent<Image>();
+        image.color = new Color(0.2f, 0.2f, 0.2f, 0.9f);
+        var button = buttonObject.AddComponent<Button>();
+
+        var labelText = CreateText(objectName + "_Label", buttonObject.transform);
+        labelText.alignment = TextAnchor.MiddleCenter;
+        labelText.text = label;
+
+        var rect = buttonObject.GetComponent<RectTransform>();
+        rect.sizeDelta = new Vector2(320f, 50f);
+
+        return button;
+    }
+
+    private void OnDisable()
+    {
+        if (enterButton != null)
+        {
+            enterButton.onClick.RemoveListener(OnEnterClicked);
+        }
+
+        if (rerollButton != null)
+        {
+            rerollButton.onClick.RemoveListener(OnRerollClicked);
+        }
+
+        if (RunManager.Instance != null)
+        {
+            RunManager.Instance.StateChanged -= Refresh;
+        }
+    }
+
+    private void OnEnterClicked()
+    {
+        if (roomFlowController != null)
+        {
+            roomFlowController.EnterEncounter();
+        }
+    }
+
+    private void OnRerollClicked()
+    {
+        if (roomFlowController != null)
+        {
+            roomFlowController.RegenerateNextEncounter();
+        }
+    }
+
+    private void Refresh()
+    {
+        var runManager = RunManager.Instance;
+        if (runManager == null || runManager.RunState == null)
+        {
+            return;
+        }
+
+        var stats = runManager.RunState.stats;
+        var encounter = roomFlowController != null ? roomFlowController.NextEncounter : runManager.CurrentEncounter;
+
+        if (dayText != null)
+        {
+            dayText.text = "Day: " + runManager.RunState.currentDay;
+        }
+
+        if (hpText != null)
+        {
+            hpText.text = "HP: " + stats.currentHp + " / " + stats.maxHp;
+        }
+
+        if (goldText != null)
+        {
+            goldText.text = "Gold: " + runManager.RunState.currentGold;
+        }
+
+        if (attackText != null)
+        {
+            attackText.text = "Attack: " + stats.attack;
+        }
+
+        if (encounterTypeText != null)
+        {
+            encounterTypeText.text = encounter != null ? "Encounter: " + encounter.encounterType : "Encounter: None";
+        }
+
+        if (encounterRewardText != null)
+        {
+            encounterRewardText.text = BuildRewardPreview(encounter);
+        }
+
+        if (enterButton != null)
+        {
+            enterButton.interactable = encounter != null;
+        }
+    }
+
+    private string BuildRewardPreview(EncounterData encounter)
+    {
+        if (encounter == null || encounter.rewards == null || encounter.rewards.Count == 0)
+        {
+            return "Reward: None";
+        }
+
+        var builder = new StringBuilder();
+        builder.Append("Reward: ");
+
+        for (int i = 0; i < encounter.rewards.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(" | ");
+            }
+
+            builder.Append(RewardSelectUI.BuildRewardLabel(encounter.rewards[i]));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/Assets/Scripts/RuntimeState/MetaProgress.cs
+++ b/Assets/Scripts/RuntimeState/MetaProgress.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class MetaProgress
+{
+    public int totalGold;
+    public int highestDay;
+    public List<string> unlockedSkillIds = new List<string>();
+    public List<string> unlockedItemIds = new List<string>();
+    public List<string> equippedItemIds = new List<string>();
+}

--- a/Assets/Scripts/RuntimeState/RunState.cs
+++ b/Assets/Scripts/RuntimeState/RunState.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class RunState
+{
+    public int currentDay;
+    public int currentGold;
+    public bool isDead;
+    public bool isCleared;
+    public StatBlock stats = new StatBlock();
+    public List<string> ownedSkillIds = new List<string>();
+    public List<string> ownedItemIds = new List<string>();
+
+    public void StartRun(StatBlock baseStats)
+    {
+        currentDay = 1;
+        currentGold = 0;
+        isDead = false;
+        isCleared = false;
+        stats = baseStats != null ? baseStats.Clone() : new StatBlock();
+        if (stats.currentHp <= 0)
+        {
+            stats.currentHp = stats.maxHp;
+        }
+
+        ownedSkillIds = new List<string>();
+        ownedItemIds = new List<string>();
+    }
+
+    public void AdvanceDay()
+    {
+        currentDay++;
+    }
+
+    public void MarkDead()
+    {
+        isDead = true;
+    }
+
+    public void MarkCleared()
+    {
+        isCleared = true;
+    }
+}

--- a/Assets/Scripts/RuntimeState/StatBlock.cs
+++ b/Assets/Scripts/RuntimeState/StatBlock.cs
@@ -1,0 +1,79 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public class StatBlock
+{
+    public int maxHp = 100;
+    public int currentHp = 100;
+    public int attack = 10;
+    public int defense = 0;
+    public int attackSpeed = 1;
+    public int critChance = 0;
+    public int critDamage = 150;
+
+    public StatBlock Clone()
+    {
+        return new StatBlock
+        {
+            maxHp = maxHp,
+            currentHp = currentHp,
+            attack = attack,
+            defense = defense,
+            attackSpeed = attackSpeed,
+            critChance = critChance,
+            critDamage = critDamage,
+        };
+    }
+
+    public void Heal(int amount)
+    {
+        if (amount <= 0)
+        {
+            return;
+        }
+
+        currentHp = Mathf.Min(maxHp, currentHp + amount);
+    }
+
+    public void TakeDamage(int amount)
+    {
+        if (amount <= 0)
+        {
+            return;
+        }
+
+        currentHp = Mathf.Max(0, currentHp - amount);
+    }
+
+    public void AddStat(StatType statType, int value)
+    {
+        if (value == 0)
+        {
+            return;
+        }
+
+        switch (statType)
+        {
+            case StatType.MaxHp:
+                maxHp += value;
+                currentHp = Mathf.Clamp(currentHp, 0, maxHp);
+                break;
+            case StatType.Attack:
+                attack += value;
+                break;
+            case StatType.Defense:
+                defense += value;
+                break;
+            case StatType.AttackSpeed:
+                attackSpeed += value;
+                break;
+            case StatType.CritChance:
+                critChance += value;
+                break;
+            case StatType.CritDamage:
+                critDamage += value;
+                break;
+        }
+    }
+}

--- a/Assets/Scripts/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Stage/StageGenerator.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+
+public static class StageGenerator
+{
+    public static StageRunData Generate(int stageId, int totalDays, int seed)
+    {
+        var random = new System.Random(seed);
+        var result = new StageRunData
+        {
+            stageId = stageId,
+            seed = seed,
+            currentDayIndex = 0,
+            days = new List<EncounterData>(),
+        };
+
+        int dayCount = totalDays < 1 ? 1 : totalDays;
+
+        for (int i = 1; i <= dayCount; i++)
+        {
+            bool isLast = i == dayCount;
+            var data = new EncounterData
+            {
+                day = i,
+                encounterId = "stage" + stageId + "_day" + i,
+                encounterType = isLast ? EncounterType.Boss : RollEncounterType(random),
+                rewards = new List<RewardData>(),
+            };
+
+            if (data.encounterType == EncounterType.Reward)
+            {
+                data.hasSelectionReward = true;
+                data.rewards.Add(RollReward(random));
+                data.rewards.Add(RollReward(random));
+                data.rewards.Add(RollReward(random));
+            }
+            else
+            {
+                data.hasSelectionReward = false;
+                data.rewards.Add(RollReward(random));
+            }
+
+            if (data.encounterType == EncounterType.Battle || data.encounterType == EncounterType.Boss)
+            {
+                data.enemyId = data.encounterType == EncounterType.Boss ? "boss_" + stageId : "enemy_" + stageId + "_" + i;
+            }
+
+            result.days.Add(data);
+        }
+
+        return result;
+    }
+
+    private static EncounterType RollEncounterType(System.Random random)
+    {
+        int roll = random.Next(0, 100);
+        if (roll < 60)
+        {
+            return EncounterType.Battle;
+        }
+
+        if (roll < 80)
+        {
+            return EncounterType.Reward;
+        }
+
+        return EncounterType.Rest;
+    }
+
+    private static RewardData RollReward(System.Random random)
+    {
+        int roll = random.Next(0, 100);
+        if (roll < 35)
+        {
+            return RewardData.CreateGold(random.Next(20, 51));
+        }
+
+        if (roll < 70)
+        {
+            return RewardData.CreateHeal(random.Next(10, 31));
+        }
+
+        StatType statType = random.Next(0, 2) == 0 ? StatType.Attack : StatType.MaxHp;
+        int amount = statType == StatType.Attack ? random.Next(1, 4) : random.Next(5, 16);
+        return RewardData.CreateStat(statType, amount);
+    }
+}

--- a/Assets/Scripts/Stage/StageRunData.cs
+++ b/Assets/Scripts/Stage/StageRunData.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class StageRunData
+{
+    public int stageId;
+    public int seed;
+    public int currentDayIndex;
+    public List<EncounterData> days = new List<EncounterData>();
+
+    public int TotalDayCount => days != null ? days.Count : 0;
+    public int CurrentDayNumber => currentDayIndex + 1;
+    public bool HasRemainingDays => days != null && currentDayIndex >= 0 && currentDayIndex < days.Count;
+
+    public EncounterData GetCurrentEncounter()
+    {
+        if (!HasRemainingDays)
+        {
+            return null;
+        }
+
+        return days[currentDayIndex];
+    }
+
+    public bool IsLastDay()
+    {
+        return HasRemainingDays && currentDayIndex == days.Count - 1;
+    }
+
+    public void AdvanceDay()
+    {
+        if (currentDayIndex < TotalDayCount)
+        {
+            currentDayIndex++;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement the designed run-based dungeon flow where a RunManager owns the run and the entire stage is pre-generated at run start.
- Move per-day generation out of RoomScene so RoomScene only displays the current pre-generated encounter and InGameScene executes it.
- Keep RunManager separate from GameManager and adapt BattleManager to report results instead of advancing days or loading scenes.

### Description
- Introduced runtime models and enums: `EncounterType`, `RewardType`, `StatType`, `StatBlock`, `RunState`, `MetaProgress`, `RewardData`, `EncounterData`, `BattleResult`, `StageRunData` and `StageGenerator` that pre-generates all days for a run. (new files under `Assets/Scripts/Data`, `Assets/Scripts/RuntimeState`, `Assets/Scripts/Stage`, `Assets/Scripts/Battle`).
- Added core run orchestration in `RunManager` (singleton, DontDestroyOnLoad) with run start, ApplyReward(s), SetCurrentHp, AdvanceDay, Clear/Unlock encounter, IsLastDay, MarkDead/MarkCleared, FinalizeRun, and `StateChanged` events. (`Assets/Scripts/Core/RunManager.cs`).
- Created Room and InGame flow controllers and UI: `RoomFlowController`, `RoomSceneUI`, `InGameSceneController`, and `RewardSelectUI` to present HUD, enter encounters, apply instant rewards, present selection UI for reward rooms, and handle result routing back from BattleManager. (new files under `Assets/Scripts/Room` and `Assets/Scripts/InGame`).
- Updated `BattleManager` so battles start via `StartEncounterBattle(EncounterData, InGameSceneController)`, build player/monster stats from run/encounter data, run the combat, and return a `BattleResult` to the scene controller instead of loading RoomScene or progressing days directly. Kept existing animation/log flow where practical and removed automatic start behavior. (`Assets/Scripts/Manager/BattleManager.cs`).
- Lightweight `GameManager` retained for scene loading; legacy reward enum in the existing `Reward.cs` was renamed to `LegacyRewardType` to avoid collisions with the new `RewardType`.
- Added a small bootstrap helper (`RunFlowBootstrap`) that ensures `RunManager` and minimal runtime flow objects exist when `RoomScene` / `InGameScene` load (useful in editor/runtime where scenes may not be pre-wired).

### Testing
- Ran repository consistency/diff checks; no formatting or diff issues reported by the checks executed after the changes.
- Performed static symbol searches to verify the new APIs are wired and referenced, including presence of `RunManager`, `InGameSceneController`, and calls to `BattleManager.StartEncounterBattle`.
- Verified the repo shows the new/updated scripts added to version control and the patch applied without file-level errors during the change set creation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6e01fb5c83309b44d7dcb18f05ff)