### PR TITLE
Add Auth emulator toggle and ensure `USE_AUTH_EMULATOR` is set in FirebaseAuthMgr

### DIFF
--- a/Assets/Scripts/Network/FirebaseAuthMgr.cs
+++ b/Assets/Scripts/Network/FirebaseAuthMgr.cs
@@ -29,6 +29,11 @@ public class FirebaseAuthMgr : MonoBehaviour
     public Text warningText;
     public Text confirmText;
 
+    [Header("Auth Emulator (Editor/Dev)")]
+    [SerializeField] private bool useAuthEmulator;
+    [SerializeField] private string authEmulatorHost = "127.0.0.1";
+    [SerializeField] private int authEmulatorPort = 9099;
+
     [Header("Profile Load")]
     [SerializeField] private int profileLoadRetryCount = 2;
     [SerializeField] private float profileRetryDelaySeconds = 0.25f;
@@ -38,6 +43,7 @@ public class FirebaseAuthMgr : MonoBehaviour
     private void Awake()
     {
         SetAuthButtonsInteractable(false);
+        EnsureAuthEmulatorEnvironmentFlag();
 
         FirebaseApp.CheckAndFixDependenciesAsync().ContinueWithOnMainThread(task =>
         {
@@ -49,6 +55,7 @@ public class FirebaseAuthMgr : MonoBehaviour
                 app.Options.DatabaseUrl = new Uri("https://soloprojm-default-rtdb.firebaseio.com/");
 
                 auth = FirebaseAuth.DefaultInstance;
+                ConfigureAuthEmulator();
                 _databaseRoot = FirebaseDatabase.GetInstance(app).RootReference;
                 _isFirebaseReady = true;
                 SetAuthButtonsInteractable(true);
@@ -66,6 +73,28 @@ public class FirebaseAuthMgr : MonoBehaviour
         LoginBtn.onClick.AddListener(() => { Login(); });
         RegisterBtn.onClick.AddListener(() => { Register(); });
         CreateIDBtn.onClick.AddListener(() => { CreateID(); });
+    }
+
+    private void EnsureAuthEmulatorEnvironmentFlag()
+    {
+        const string envKey = "USE_AUTH_EMULATOR";
+        string value = Environment.GetEnvironmentVariable(envKey);
+
+        if (string.IsNullOrEmpty(value))
+        {
+            Environment.SetEnvironmentVariable(envKey, useAuthEmulator ? "1" : "0");
+        }
+    }
+
+    private void ConfigureAuthEmulator()
+    {
+        if (auth == null || !useAuthEmulator)
+        {
+            return;
+        }
+
+        auth.UseEmulator(authEmulatorHost, authEmulatorPort);
+        Debug.Log($"[FirebaseAuthMgr] Auth emulator enabled: {authEmulatorHost}:{authEmulatorPort}");
     }
 
     private void Start()


### PR DESCRIPTION
### Motivation
- Silence repeated `USE_AUTH_EMULATOR not set` messages and provide a safe default when the environment flag is missing.
- Allow developers to enable the Firebase Auth emulator from the Unity inspector for local/editor workflows.
- Make emulator configuration deterministic at runtime so `FirebaseAuth` can be pointed to the emulator when desired.

### Description
- Added inspector-configurable fields `useAuthEmulator`, `authEmulatorHost`, and `authEmulatorPort` to `FirebaseAuthMgr` with sensible defaults. 
- Introduced `EnsureAuthEmulatorEnvironmentFlag()` which sets the `USE_AUTH_EMULATOR` environment variable to `0` or `1` when it is unset, and calls it early in `Awake()` to prevent the SDK log. 
- Added `ConfigureAuthEmulator()` and invoked it after `auth = FirebaseAuth.DefaultInstance;` so `auth.UseEmulator(host, port)` is called only when `useAuthEmulator` is enabled.

### Testing
- No automated tests were executed for this change (Unity editor/runtime validation required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8de48b4788330bd48bff7d5f5777e)