### PR TITLE
Improve UI robustness, add Firebase auth env bootstrap, and refactor StateUI updates

### DIFF
--- a/Assets/Scripts/InGame/RewardSelectUI.cs
+++ b/Assets/Scripts/InGame/RewardSelectUI.cs
@@ -34,10 +34,16 @@ public class RewardSelectUI : MonoBehaviour
             rootPanel.SetActive(true);
         }
 
+        if (optionButtons == null || optionButtons.Length == 0)
+        {
+            Debug.LogWarning("[RewardSelectUI] optionButtons is empty.");
+            return;
+        }
+
         for (int i = 0; i < optionButtons.Length; i++)
         {
             var button = optionButtons[i];
-            var text = i < optionTexts.Length ? optionTexts[i] : null;
+            var text = (optionTexts != null && i < optionTexts.Length) ? optionTexts[i] : null;
             if (button == null)
             {
                 continue;
@@ -153,7 +159,13 @@ public class RewardSelectUI : MonoBehaviour
         var textObject = new GameObject(objectName);
         textObject.transform.SetParent(parent, false);
         var text = textObject.AddComponent<Text>();
-        text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        text.font = Font.CreateDynamicFontFromOSFont("Arial", 24);
+        if (text.font == null)
+        {
+            Debug.LogWarning("[RewardSelectUI] OS Arial font not found. Using Unity default font fallback.");
+            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+        }
+
         text.color = Color.white;
         text.fontSize = 24;
         text.text = value;

--- a/Assets/Scripts/Network/FirebaseAuthEnvironmentBootstrap.cs
+++ b/Assets/Scripts/Network/FirebaseAuthEnvironmentBootstrap.cs
@@ -1,0 +1,19 @@
+using System;
+using UnityEngine;
+
+public static class FirebaseAuthEnvironmentBootstrap
+{
+    private const string UseAuthEmulatorKey = "USE_AUTH_EMULATOR";
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
+    private static void EnsureAuthEmulatorFlag()
+    {
+        string value = Environment.GetEnvironmentVariable(UseAuthEmulatorKey);
+        if (!string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(UseAuthEmulatorKey, "0");
+    }
+}

--- a/Assets/Scripts/Network/FirebaseAuthEnvironmentBootstrap.cs.meta
+++ b/Assets/Scripts/Network/FirebaseAuthEnvironmentBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bd7307b3097444ea902dd0a830ec4f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/FirebaseAuthMgr.cs
+++ b/Assets/Scripts/Network/FirebaseAuthMgr.cs
@@ -29,6 +29,7 @@ public class FirebaseAuthMgr : MonoBehaviour
     public Text warningText;
     public Text confirmText;
 
+
     [Header("Profile Load")]
     [SerializeField] private int profileLoadRetryCount = 2;
     [SerializeField] private float profileRetryDelaySeconds = 0.25f;

--- a/Assets/Scripts/UI/StateUI.cs
+++ b/Assets/Scripts/UI/StateUI.cs
@@ -1,38 +1,66 @@
-using System.Collections;
 using TMPro;
 using UnityEngine;
 
 public class StateUI : MonoBehaviour
 {
-    UnitStats player;
+    [SerializeField] private TextMeshProUGUI LvlText;
+    [SerializeField] private TextMeshProUGUI HpText;
+    [SerializeField] private TextMeshProUGUI AtkText;
+    [SerializeField] private TextMeshProUGUI DefText;
 
-    [SerializeField] TextMeshProUGUI LvlText;
-    [SerializeField] TextMeshProUGUI HpText;
-    [SerializeField] TextMeshProUGUI AtkText;
-    [SerializeField] TextMeshProUGUI DefText;
-
-    // Start is called before the first frame update
-    void Start()
+    private void OnEnable()
     {
-        StartCoroutine(PlayerSetting());
+        if (RunManager.Instance != null)
+        {
+            RunManager.Instance.StateChanged += Refresh;
+        }
+
+        Refresh();
     }
 
-
-    IEnumerator PlayerSetting()
+    private void OnDisable()
     {
-        Debug.Log("StateUI - PlayerSetting");
-        yield return new WaitUntil(() => GameManager.Instance.GetPlayer() != null); // 전투 시작 대기
-        //모든 추가능력치 다 합쳐진거 호출
-        player = GameManager.Instance.GetPlayer().GetStats();
-
-        LvlText.text = "LV." + player.Lv.ToString();
-        HpText.text = player.CurrentHp.ToString() + "/" + player.MaxHp.ToString();
-        AtkText.text = player.Attack.ToString();
-        DefText.text = player.Defense.ToString();
-        Debug.Log(AtkText.text);
-        Debug.Log(DefText.text);
+        if (RunManager.Instance != null)
+        {
+            RunManager.Instance.StateChanged -= Refresh;
+        }
     }
 
-    //추후 1만 넘어가면 K 단위로 나눌거임
+    private void Refresh()
+    {
+        var runManager = RunManager.Instance;
+        var profile = GameManager.Instance != null ? GameManager.Instance.PlayerProfile : null;
 
+        if (runManager != null && runManager.RunState != null && runManager.RunState.stats != null)
+        {
+            var stats = runManager.RunState.stats;
+            SetText(LvlText, "LV." + Mathf.Max(1, profile != null && profile.stats != null ? profile.stats.level : 1));
+            SetText(HpText, stats.currentHp + "/" + stats.maxHp);
+            SetText(AtkText, stats.attack.ToString());
+            SetText(DefText, stats.defense.ToString());
+            return;
+        }
+
+        if (profile != null && profile.stats != null)
+        {
+            SetText(LvlText, "LV." + Mathf.Max(1, profile.stats.level));
+            SetText(HpText, profile.stats.maxHp + "/" + profile.stats.maxHp);
+            SetText(AtkText, Mathf.Max(1, profile.stats.attack).ToString());
+            SetText(DefText, Mathf.Max(0, profile.stats.defense).ToString());
+            return;
+        }
+
+        SetText(LvlText, "LV.-");
+        SetText(HpText, "-/ -");
+        SetText(AtkText, "-");
+        SetText(DefText, "-");
+    }
+
+    private static void SetText(TMP_Text text, string value)
+    {
+        if (text != null)
+        {
+            text.text = value;
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent runtime null-reference and font issues in reward selection UI and make font loading more robust across platforms.
- Ensure a stable default for Firebase Auth emulator flag early in startup to avoid environment-dependent behavior.
- Replace a coroutine-based `StateUI` initialization with event-driven updates to keep UI in sync with runtime state and avoid race conditions.

### Description
- In `RewardSelectUI.cs` added a guard to early-return with a warning when `optionButtons` is null or empty, and made `optionTexts` indexing safe by checking for null and bounds before use.
- In `RewardSelectUI.cs` changed text font creation to use `Font.CreateDynamicFontFromOSFont("Arial", 24)` with a fallback to the built-in Unity font and a warning log if the OS font is not found, keeping text color and size settings.
- Added `FirebaseAuthEnvironmentBootstrap.cs` which sets the `USE_AUTH_EMULATOR` environment variable to a default of `0` at `BeforeSplashScreen` to ensure a defined value early in runtime.
- Refactored `StateUI.cs` to use `OnEnable`/`OnDisable` and subscribe to `RunManager.Instance.StateChanged`, added a `Refresh` method and helper `SetText` to update UI fields from either the current run state or the saved `PlayerProfile`, and removed the previous coroutine-based initialization.
- Minor formatting/spacing cleanup in `FirebaseAuthMgr.cs` (no logic changes beyond whitespace).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8de48b4788330bd48bff7d5f5777e)